### PR TITLE
Refactor urlpatterns / Django 4 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,9 @@ repos:
       - id: end-of-file-fixer
         exclude: \.(min\.css|min\.js|po|mo)$
       - id: mixed-line-ending
-        args: [ '--fix=lf' ]
+        args: [ --fix=lf ]
       - id: fix-encoding-pragma
-        args: [ '--remove' ]
+        args: [ --remove ]
       - id: detect-private-key
       - id: check-added-large-files
       - id: check-ast  # Is it valid Python?
@@ -33,7 +33,7 @@ repos:
         exclude: ^(LICENSE)
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [ --py37-plus ]
@@ -49,17 +49,17 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [ black==21.12b0 ]
+        additional_dependencies: [ black==22.1.0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Using `path` in URL config instead of soon-to-be removed `url`
 - Minimum requirements
   - Alliance Auth v2.9.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
+  'ugettext_lazy' from 'django.utils.translation'
+
 
 ## [0.1.0-alpha.9] - 2022-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+
+## [0.1.0-alpha.9] - 2022-02-02
+
 ### Added
 
 - Tests for Python 3.11

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ graph_models:
 
 coverage:
 	rm -rfv htmlcov && \
-	coverage run ../myauth/manage.py test $(package) --keepdb --failfast && coverage html && coverage report
+	coverage run ../myauth/manage.py test $(package) --keepdb --failfast && coverage html && coverage report -m
 
 build_test:
 	rm -rfv dist && \

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
 [![Checks](https://github.com/ppfeufer/aa-fleetfinder/actions/workflows/automated-checks.yml/badge.svg)](https://github.com/ppfeufer/aa-fleetfinder/actions/workflows/automated-checks.yml)
 [![codecov](https://codecov.io/gh/ppfeufer/aa-fleetfinder/branch/master/graph/badge.svg?token=GFOR9GWRNQ)](https://codecov.io/gh/ppfeufer/aa-fleetfinder)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/ppfeufer/aa-fleetfinder/blob/master/CODE_OF_CONDUCT.md)
+
+## Not yet publicly available

--- a/fleetfinder/__init__.py
+++ b/fleetfinder/__init__.py
@@ -4,13 +4,12 @@ init
 
 default_app_config: str = "fleetfinder.apps.FleetFinderConfig"
 
+github_url = "https://github.com/ppfeufer/aa-fleetfinder"
+
 __title__ = "Fleet Finder"
-__version__ = "0.1.0-alpha.8"
+__version__ = "0.1.0-alpha.9"
 
 __verbose_name__ = "Fleet Finder for Alliance Auth"
 __user_agent_name__ = "Fleet-Finder-for-Alliance-Auth"
-__user_agent__ = "{verbose_name} v{version} {github_url}".format(
-    verbose_name=__user_agent_name__,
-    version=__version__,
-    github_url="https://github.com/ppfeufer/aa-fleetfinder",
-)
+
+__user_agent__ = f"{__verbose_name__} v{__version__} {github_url}"

--- a/fleetfinder/auth_hooks.py
+++ b/fleetfinder/auth_hooks.py
@@ -3,7 +3,7 @@ auth hooks
 """
 
 # Django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
 from allianceauth import hooks

--- a/fleetfinder/urls.py
+++ b/fleetfinder/urls.py
@@ -1,9 +1,9 @@
 """
-url config
+URL config
 """
 
 # Django
-from django.conf.urls import url
+from django.urls import path
 
 # AA Fleet Finder
 from fleetfinder import views
@@ -11,20 +11,16 @@ from fleetfinder import views
 app_name: str = "fleetfinder"
 
 urlpatterns = [
-    url(r"^$", views.dashboard, name="dashboard"),
-    url(r"^create/$", views.create_fleet, name="create_fleet"),
-    url(r"^save/$", views.save_fleet, name="save_fleet"),
-    url(r"^join/(?P<fleet_id>[0-9]+)/$", views.join_fleet, name="join_fleet"),
-    url(r"^details/(?P<fleet_id>[0-9]+)/$", views.fleet_details, name="fleet_details"),
-    url(r"^edit/(?P<fleet_id>[0-9]+)/$", views.edit_fleet, name="edit_fleet"),
+    path("", views.dashboard, name="dashboard"),
+    path("create/", views.create_fleet, name="create_fleet"),
+    path("save/", views.save_fleet, name="save_fleet"),
+    path("join/<int:fleet_id>/", views.join_fleet, name="join_fleet"),
+    path("details/<int:fleet_id>/", views.fleet_details, name="fleet_details"),
+    path("edit/<int:fleet_id>/", views.edit_fleet, name="edit_fleet"),
     # ajax calls
-    url(
-        r"^call/dashboard/$",
-        views.ajax_dashboard,
-        name="ajax_dashboard",
-    ),
-    url(
-        r"^call/details/(?P<fleet_id>[0-9]+)/$",
+    path("call/dashboard/", views.ajax_dashboard, name="ajax_dashboard"),
+    path(
+        "call/details/<int:fleet_id>/",
         views.ajax_fleet_details,
         name="ajax_fleet_details",
     ),

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,5 @@ install_command = python -m pip install -U {opts} {packages}
 
 commands=
     coverage run runtests.py fleetfinder -v 2
-    coverage report
+    coverage report -m
     coverage xml


### PR DESCRIPTION
## Description

### Fixed

- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
  'ugettext_lazy' from 'django.utils.translation'

### Added

- Tests for Python 3.11

### Changed

- Using `path` in URL config instead of soon-to-be removed `url`
- Minimum requirements
  - Alliance Auth v2.9.4


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
