### PR TITLE
[RELEASE] v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [2.4.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/fleetfinder/__init__.py
+++ b/fleetfinder/__init__.py
@@ -5,6 +5,6 @@ Initialize the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.3.4"
+__version__ = "2.4.0"
 __title__ = _("Fleet Finder")
 __verbose_name__ = "Fleet Finder for Alliance Auth"

--- a/fleetfinder/locale/django.pot
+++ b/fleetfinder/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Fleet Finder 2.3.4\n"
+"Project-Id-Version: AA Fleet Finder 2.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-fleetfinder/issues\n"
-"POT-Creation-Date: 2025-05-05 21:13+0200\n"
+"POT-Creation-Date: 2025-06-03 10:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.4.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.