### PR TITLE
[RELEASE] v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.6.1] - 2025-08-19
+
 ### Fixed
 
 - FC can't see their own fleet when not in selected group(s)

--- a/fleetfinder/__init__.py
+++ b/fleetfinder/__init__.py
@@ -5,7 +5,7 @@ Initialize the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"
 __title__ = _("Fleet Finder")
 __verbose_name__ = "Fleet Finder for Alliance Auth"
 

--- a/fleetfinder/locale/django.pot
+++ b/fleetfinder/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Fleet Finder 2.6.0\n"
+"Project-Id-Version: AA Fleet Finder 2.6.1\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-fleetfinder/issues\n"
-"POT-Creation-Date: 2025-08-19 16:57+0200\n"
+"POT-Creation-Date: 2025-08-19 17:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.6.1] - 2025-08-19

### Fixed

- FC can't see their own fleet when not in selected group(s)

### Changed

- `views.ajax_fleet_details` refactored
- `tasks._process_fleet` refactored
- `tasks.open_fleet` refactored
- `tasks.send_fleet_invitation` refactored
- `tasks.check_fleet_adverts` refactored
- `tasks.get_fleet_composition` refactored
- Fleet creation logic refactored, and better error handling added

### Removed

- MOTD from fleet details form, as it cannot be formatted properly and might delete the ingame MOTD when not set