### PR TITLE
[CHANGE] Set chunk size for ESI calls to `post_universe_names` to 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Set chunk size for ESI calls to `Universe.post_universe_names` to 1000 to match the limit for this endpoint
+
 ## [2.7.0] - 2025-08-21
 
 ### Added

--- a/fleetfinder/tasks.py
+++ b/fleetfinder/tasks.py
@@ -342,8 +342,14 @@ def get_fleet_composition(  # pylint: disable=too-many-locals
             f"Found {len(all_ids)} unique IDs to fetch names for in fleet {fleet_id}"
         )
 
-        # Process IDs in chunks to avoid ESI limits
-        chunk_size = 500
+        # Process IDs in chunks of 1000 to avoid ESI limits.
+        # ESI has a limit of 1000 IDs per request, so we will chunk the requests,
+        # even though there is a theoretical limit of 768 unique IDs per fleet,
+        # so we never should hit the ESI limit.
+        # But to be on the safe side, we will chunk the requests in case CCP decides
+        # to change the fleet limit in the future, we will use a chunk size of 1000,
+        # which is the maximum allowed by ESI for the `post_universe_names` endpoint.
+        chunk_size = 1000
         ids_to_name = []
         all_ids_list = list(all_ids)
 


### PR DESCRIPTION
## Description

### Changed

- Set chunk size for ESI calls to `Universe.post_universe_names` to 1000 to match the limit for this endpoint

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
