### PR TITLE
[RELEASE] v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [4.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -771,7 +773,8 @@ App forked from [Dreadbomb/aa-fleet]
 [3.2.4]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.2.3...v3.2.4 "v3.2.4"
 [3.2.5]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.2.4...v3.2.5 "v3.2.5"
 [3.3.0]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.2.5...v3.3.0 "v3.3.0"
+[4.0.0]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.3.0...v4.0.0 "v4.0.0"
 [dreadbomb/aa-fleet]: https://github.com/Dreadbomb/aa-fleet "Dreadbomb/aa-fleet"
-[in development]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.3.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-fleetfinder/compare/v4.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ______________________________________________________________________
 Make sure you're in the virtual environment (venv) of your Alliance Auth installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-fleetfinder==3.3.0
+pip install aa-fleetfinder==4.0.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/fleetfinder/__init__.py
+++ b/fleetfinder/__init__.py
@@ -5,7 +5,7 @@ Initialize the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.3.0"
+__version__ = "4.0.0"
 __title__ = "Fleet Finder"
 __title_translated__ = _("Fleet Finder")
 __verbose_name__ = "Fleet Finder for Alliance Auth"

--- a/fleetfinder/locale/django.pot
+++ b/fleetfinder/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Fleet Finder 3.2.5\n"
+"Project-Id-Version: AA Fleet Finder 4.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-fleetfinder/issues\n"
-"POT-Creation-Date: 2026-05-05 14:27+0200\n"
+"POT-Creation-Date: 2026-06-07 11:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -148,16 +148,16 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: fleetfinder/templates/fleetfinder/fleet-details.html:82
+#: fleetfinder/templates/fleetfinder/fleet-details.html:84
 msgid "Fleet boss"
 msgstr ""
 
-#: fleetfinder/templates/fleetfinder/fleet-details.html:83
+#: fleetfinder/templates/fleetfinder/fleet-details.html:85
 #: fleetfinder/templates/fleetfinder/modals/kick-fleet-member.html:9
 msgid "Kick member from fleet"
 msgstr ""
 
-#: fleetfinder/templates/fleetfinder/fleet-details.html:84
+#: fleetfinder/templates/fleetfinder/fleet-details.html:86
 msgid "An unknown error occurred."
 msgstr ""
 


### PR DESCRIPTION
## [4.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Changed

- DataTables are now responsive

### Removed

- Support for Alliance Auth v4