### PR TITLE
[RELEASE] v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,16 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [4.0.1] - 2026-07-06
+
+### Added
+
+- Support for Python 3.14
+
 ### Changed
 
-- Migration dependency updates to squashed migrations in Alliance Auth v5
+- Migration dependency updated to squashed migrations in Alliance Auth v5
+- Translations updated
 
 ## [4.0.0] - 2026-06-07
 
@@ -778,7 +785,8 @@ App forked from [Dreadbomb/aa-fleet]
 [3.2.5]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.2.4...v3.2.5 "v3.2.5"
 [3.3.0]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.2.5...v3.3.0 "v3.3.0"
 [4.0.0]: https://github.com/ppfeufer/aa-fleetfinder/compare/v3.3.0...v4.0.0 "v4.0.0"
+[4.0.1]: https://github.com/ppfeufer/aa-fleetfinder/compare/v4.0.0...v4.0.1 "v4.0.1"
 [dreadbomb/aa-fleet]: https://github.com/Dreadbomb/aa-fleet "Dreadbomb/aa-fleet"
-[in development]: https://github.com/ppfeufer/aa-fleetfinder/compare/v4.0.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-fleetfinder/compare/v4.0.1...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ______________________________________________________________________
 Make sure you're in the virtual environment (venv) of your Alliance Auth installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-fleetfinder==4.0.0
+pip install aa-fleetfinder==4.0.1
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/fleetfinder/__init__.py
+++ b/fleetfinder/__init__.py
@@ -5,7 +5,7 @@ Initialize the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __title__ = "Fleet Finder"
 __title_translated__ = _("Fleet Finder")
 __verbose_name__ = "Fleet Finder for Alliance Auth"

--- a/fleetfinder/locale/django.pot
+++ b/fleetfinder/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Fleet Finder 4.0.0\n"
+"Project-Id-Version: AA Fleet Finder 4.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-fleetfinder/issues\n"
-"POT-Creation-Date: 2026-06-07 11:44+0200\n"
+"POT-Creation-Date: 2026-07-06 21:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [4.0.1] - 2026-07-06

### Added

- Support for Python 3.14

### Changed

- Migration dependency updated to squashed migrations in Alliance Auth v5
- Translations updated
